### PR TITLE
Check if uri contains wp-content/uploads

### DIFF
--- a/WordPressProxyValetDriver.php
+++ b/WordPressProxyValetDriver.php
@@ -110,8 +110,10 @@ class WordPressProxyValetDriver extends WordPressValetDriver
     public function shouldProxy($uri)
     {
         $extension = pathinfo($uri, PATHINFO_EXTENSION);
+        $dirName = pathinfo($uri, PATHINFO_DIRNAME);
 
-        return in_array($extension, $this->proxyable);
+        return in_array($extension, $this->proxyable) &&
+            strpos($dirName, 'wp-content/uploads') !== false;
     }
 
     /**


### PR DESCRIPTION
This check in `shouldProxy` method prevents images in your theme from being proxied. This is helpful when developing a new theme.